### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ XNGAPIClientTester
 [![Build Status](https://travis-ci.org/xing/XNGAPIClientTester.svg)](https://travis-ci.org/xing/XNGAPIClientTester)
 [![Coverage Status](http://img.shields.io/coveralls/xing/XNGAPIClientTester/master.svg?style=flat)](https://coveralls.io/r/xing/XNGAPIClientTester)
 [![Dependency Status](https://www.versioneye.com/objective-c/xngapiclienttester/badge.svg?style=flat)](https://www.versioneye.com/objective-c/xngapiclienttester)
-[![Cocoapods Version](http://img.shields.io/cocoapods/v/XNGAPIClientTester.svg?style=flat)](https://github.com/xing/XNGAPIClientTester/blob/master/XNGAPIClientTester.podspec)
+[![CocoaPods Version](http://img.shields.io/cocoapods/v/XNGAPIClientTester.svg?style=flat)](https://github.com/xing/XNGAPIClientTester/blob/master/XNGAPIClientTester.podspec)
 [![](http://img.shields.io/cocoapods/l/XNGAPIClientTester.svg?style=flat)](https://github.com/xing/XNGAPIClientTester/blob/master/LICENSE)
 [![CocoaPods Platform](http://img.shields.io/cocoapods/p/XNGAPIClientTester.svg?style=flat)]()
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
